### PR TITLE
fix: mark include-read-only and all-organizations flags on channels exclusive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 			},
 			"devDependencies": {
 				"@semantic-release/git": "^10.0.1",
-				"@smartthings/cli-testlib": "^1.0.0-beta.1",
+				"@smartthings/cli-testlib": "file:../smartthings-cli/packages/testlib/smartthings-cli-testlib-1.0.0-beta.0.tgz",
 				"@types/cli-table": "^0.3.0",
 				"@types/eventsource": "^1.1.8",
 				"@types/inquirer": "^8.2.1",
@@ -2410,12 +2410,13 @@
 			}
 		},
 		"node_modules/@smartthings/cli-testlib": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.1.tgz",
-			"integrity": "sha512-aPgHr/WR51FUbAOZac1ttwXf2IlW/q4BV/I0kr+c2QI+VyhjDvcnGYHLDRSfbhM7nCH9S/UyeVSLdcA+a4htaA==",
+			"version": "1.0.0-beta.0",
+			"resolved": "file:../smartthings-cli/packages/testlib/smartthings-cli-testlib-1.0.0-beta.0.tgz",
+			"integrity": "sha512-JyuVFMCv0GRt0EHxPI6xQtLPrKb8Zt9yRZdq/SlIjzy4ZDxo8AoQIh+NivUjaII/TME/77KZeVhMjAU/xvP0ag==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smartthings/cli-lib": "^1.0.0-beta.1"
+				"@smartthings/cli-lib": "^1.0.0-beta.0"
 			},
 			"engines": {
 				"node": ">=12.18.1 <17",
@@ -19599,12 +19600,11 @@
 			}
 		},
 		"@smartthings/cli-testlib": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/cli-testlib/-/cli-testlib-1.0.0-beta.1.tgz",
-			"integrity": "sha512-aPgHr/WR51FUbAOZac1ttwXf2IlW/q4BV/I0kr+c2QI+VyhjDvcnGYHLDRSfbhM7nCH9S/UyeVSLdcA+a4htaA==",
+			"version": "file:../smartthings-cli/packages/testlib/smartthings-cli-testlib-1.0.0-beta.0.tgz",
+			"integrity": "sha512-JyuVFMCv0GRt0EHxPI6xQtLPrKb8Zt9yRZdq/SlIjzy4ZDxo8AoQIh+NivUjaII/TME/77KZeVhMjAU/xvP0ag==",
 			"dev": true,
 			"requires": {
-				"@smartthings/cli-lib": "^1.0.0-beta.1"
+				"@smartthings/cli-lib": "^1.0.0-beta.0"
 			}
 		},
 		"@smartthings/core-sdk": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@semantic-release/git": "^10.0.1",
-		"@smartthings/cli-testlib": "^1.0.0-beta.1",
+		"@smartthings/cli-testlib": "file:../smartthings-cli/packages/testlib/smartthings-cli-testlib-1.0.0-beta.0.tgz",
 		"@types/cli-table": "^0.3.0",
 		"@types/eventsource": "^1.1.8",
 		"@types/inquirer": "^8.2.1",

--- a/src/commands/edge/channels.ts
+++ b/src/commands/edge/channels.ts
@@ -18,6 +18,7 @@ export default class ChannelsCommand extends EdgeCommand {
 		'include-read-only': Flags.boolean({
 			char: 'I',
 			description: 'include subscribed-to channels as well as owned channels',
+			exclusive: ['all-organizations'],
 		}),
 		'subscriber-type': Flags.string({
 			description: 'filter results based on subscriber type',
@@ -62,7 +63,11 @@ $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>`]
 		}
 
 		await outputListing(this, config, args.idOrIndex,
-			async () => listChannels(this, flags['subscriber-type'] as SubscriberType | undefined, flags['subscriber-id']),
+			async () => listChannels(this.client, {
+				subscriberType: flags['subscriber-type'] as SubscriberType | undefined,
+				subscriberId: flags['subscriber-id'],
+				includeReadOnly: flags['include-read-only'],
+			}),
 			id => this.client.channels.get(id))
 	}
 }

--- a/test/unit/commands/edge/channels.test.ts
+++ b/test/unit/commands/edge/channels.test.ts
@@ -1,4 +1,4 @@
-import { Channel, ChannelsEndpoint } from '@smartthings/core-sdk'
+import { Channel, ChannelsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { APICommand, outputListing } from '@smartthings/cli-lib'
 
@@ -78,7 +78,8 @@ describe('ChannelsCommand', () => {
 		expect(await listFunction()).toBe(channelList)
 
 		expect(listChannelsMock).toHaveBeenCalledTimes(1)
-		expect(listChannelsMock).toHaveBeenCalledWith(expect.any(APICommand), 'HUB', 'subscriber-id')
+		expect(listChannelsMock).toHaveBeenCalledWith(expect.any(SmartThingsClient),
+			{ subscriberType: 'HUB', subscriberId: 'subscriber-id' })
 	})
 
 	test('get item function uses channels.get with id', async () => {


### PR DESCRIPTION
* clean up `listChannels` function to not allow `includeReadOnly` and `allOrganizations` at the same time
* updated `edge:channels` command to mark the corresponding flags exclusive of each other

<!-- Describe your pull request. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
